### PR TITLE
Dimension/Dimension Type file descriptions/links

### DIFF
--- a/docs/docs/dimensions/dimension-types/latest.md
+++ b/docs/docs/dimensions/dimension-types/latest.md
@@ -11,7 +11,7 @@ nav_order: 2
 
 Dimension type files control the properties of a dimension. These properties include things like whether beds work or not, whether sky light should be calculated, etc.
 
-Unlike other worldgen files, they are **not** stored in the `/worldgen` folder. They are stored in their own `/dimension_type` folder.
+Unlike other worldgen files, they are **not** stored in the `/worldgen` folder. They are stored in their own `/dimension_type` folder. The file is named based on the dimension it represents. For instance, the overworld's dimension type file will be named `overworld.json` (just like the dimension file).
 
 Let's take a look at an example dimension type file, this one being for the Overworld:
 

--- a/docs/docs/dimensions/introduction.md
+++ b/docs/docs/dimensions/introduction.md
@@ -67,7 +67,7 @@ Let's take a look at an example dimension file. This one is identical to the Ove
 
 The settings are as follows:
 
-* `type`: The dimension type file this dimension uses. Learn how dimension files work [here](https://apollodatapacks.github.io/docs/dimension-types/).
+* `type`: The dimension type file this dimension uses. Learn how dimension files work [here](https://www.worldgen.dev/docs/dimension-types/).
 * `generator`: Controls the terrain generation and biome source for the dimension.
 	* `type`: The generator type.
 		* If set to `minecraft:debug`, there are no further fields. This is only used for the `debug` world type, and doesn't have any practical use.
@@ -93,4 +93,4 @@ The settings are as follows:
 						* `biomes`: A list of biomes that is used in the checkerboard.
 					* If set to `minecraft:multi_noise`, the settings are as follows:
 						* `preset`: The preset for the biome layout. Can be either `minecraft:overworld` or `minecraft:nether`. **Mutually exclusive with the `biomes` field!**
-						* `biomes`: A list of biomes with their respective parameters. Biome parameters are a complex subject and will soon have their own page. **Mutually exclusive with the `preset` field!**
+						* `biomes`: A list of biomes with their respective parameters. Biome parameters are a complex subject, so they have their own page [here](https://www.worldgen.dev/docs/dimensions/multi-noise/latest/). **Mutually exclusive with the `preset` field!**

--- a/docs/docs/dimensions/introduction.md
+++ b/docs/docs/dimensions/introduction.md
@@ -20,7 +20,7 @@ In order for Minecraft to register a dimension, it needs to know three things ab
 
 Dimension files supply the game with all of this information.
 
-Unlike other worldgen files, they are **not** stored in the `/worldgen` folder. They are stored in their own `/dimension` folder.
+Unlike other worldgen files, they are **not** stored in the `/worldgen` folder. They are stored in their own `/dimension` folder. The file is named based on the dimension it represents. For instance, the overworld's dimension file will be named `overworld.json`.
 
 Let's take a look at an example dimension file. This one is identical to the Overworld, except the only biome is the Plains:
 


### PR DESCRIPTION
Added an explination that the files are named after the dimension, plus a hyperlink to the multi-noise biome source in place of the "page coming soon" within the dimension file description.